### PR TITLE
Add Git SSH URLs

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -6,7 +6,7 @@
 #===============================================================================
 
 fzf_cmd() {
-    fzf-tmux -d 35% --multi --exit-0 --cycle --reverse --bind='ctrl-r:toggle-all' --bind='ctrl-s:toggle-sort'
+    fzf-tmux -d 35% --multi --exit-0 --cycle --reverse --bind='ctrl-r:toggle-all' --bind='ctrl-s:toggle-sort' --no-preview
 }
 
 if  hash xdg-open &>/dev/null; then
@@ -19,6 +19,7 @@ content="$(tmux capture-pane -J -p)"
 urls=($(echo "$content" |grep -oE '(https?|ftp|file)://[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]'))
 wwws=($(echo "$content" |grep -oE 'www\.[a-zA-Z](-?[a-zA-Z0-9])+\.[a-zA-Z]{2,}(/\S+)*'                  |sed 's/^\(.*\)$/http:\/\/\1/'))
 ips=($(echo  "$content" |grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?(/\S+)*' |sed 's/^\(.*\)$/http:\/\/\1/'))
+gits=($(echo "$content" |grep -oE '(ssh://)?git@\S*' | sed 's/:/\//g' | sed 's/^\(ssh\/\/\/\)\{0,1\}git@\(.*\)$/https:\/\/\2/'))
 
 merge() {
     for item in "$@" ; do
@@ -26,7 +27,7 @@ merge() {
     done
 }
 
-merge "${urls[@]}" "${wwws[@]}" "${ips[@]}"|
+merge "${urls[@]}" "${wwws[@]}" "${ips[@]}" "${gits[@]}"|
     sort -u |
     nl -w3 -s '  ' |
     fzf_cmd |


### PR DESCRIPTION
Hi, I added Git SSH URLs parsing, as all my `git clone` work is done via SSH.
In addition, AFAIS, the `fzf` command line would work better without `preview` option in this case.
Thanks