### PR TITLE
Use $BROWSER if "xdg-open" and "open" are not present

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -13,6 +13,8 @@ if  hash xdg-open &>/dev/null; then
     open_cmd='nohup xdg-open'
 elif hash open &>/dev/null; then
     open_cmd='open'
+elif [[ -v BROWSER ]]; then
+    open_cmd="$BROWSER"
 fi
 
 content="$(tmux capture-pane -J -p)"


### PR DESCRIPTION
I'm using NixOS without xdg-utils and would appreciate support for the BROWSER environment variable.