### PR TITLE
fix: "conditional binary operator expected" error

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -13,7 +13,7 @@ if  hash xdg-open &>/dev/null; then
     open_cmd='nohup xdg-open'
 elif hash open &>/dev/null; then
     open_cmd='open'
-elif [[ -v BROWSER ]]; then
+elif [ -z ${BROWSER+x} ]; then
     open_cmd="$BROWSER"
 fi
 


### PR DESCRIPTION
I got the error message like below:

```
fzf-url.sh|16 error| [shell] [E] conditional binary operator expected
fzf-url.sh|16 error| [shell] [E] syntax error near `BROWSER'
fzf-url.sh|16 error| [shell] [E] `elif [[ -v BROWSER ]]; then'
```

IMHO, `-v` is a zsh feature

Ref:
- <https://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash>