### PR TITLE
Count the length of the stringified $BROWSER variable

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -13,7 +13,7 @@ if  hash xdg-open &>/dev/null; then
     open_cmd='nohup xdg-open'
 elif hash open &>/dev/null; then
     open_cmd='open'
-elif [[ -v BROWSER ]]; then
+elif [[ -n $BROWSER ]]; then
     open_cmd="$BROWSER"
 fi
 


### PR DESCRIPTION
Hi @wfxr, I ran into an issue while trying to run this plugin and I think it's related to zsh. I tried to run the plugin with `<prefix> + u` and I got errcode 2. Then I ran `fzf-url.sh` on it's own and I got this trace
```
./fzf-url.sh: line 16: conditional binary operator expected
./fzf-url.sh: line 16: syntax error near `BROWSER'
./fzf-url.sh: line 16: `elif [[ -v BROWSER ]]; then'
```
I fixed it by using -n to count the length of the stringified variable instead of -v to check if it is unset. I think these should be functionally equivalent maybe better supported between the different shells. I also tested in bash and sh and they seemed to work fine as well.