### PR TITLE
Using entire buffer scrollback as target content

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -19,7 +19,7 @@ open_url() {
     fi
 }
 
-content="$(tmux capture-pane -J -p)"
+content="$(tmux capture-pane -J -p -S -"$2")"
 
 mapfile -t urls < <(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]')
 mapfile -t wwws < <(echo "$content" |grep -oE 'www\.[a-zA-Z](-?[a-zA-Z0-9])+\.[a-zA-Z]{2,}(/\S+)*'                  |sed 's/^\(.*\)$/http:\/\/\1/')

--- a/fzf-url.tmux
+++ b/fzf-url.tmux
@@ -15,7 +15,8 @@ tmux_get() {
 }
 
 key="$(tmux_get '@fzf-url-bind' 'u')"
+historyLimit="$(tmux_get 'history-limit' '2000')"
 extra_filter="$(tmux_get '@fzf-url-extra-filter' '')"
 echo "$extra_filter" > /tmp/filter
 
-tmux bind-key "$key" run -b "$SCRIPT_DIR/fzf-url.sh '$extra_filter'";
+tmux bind-key "$key" run -b "$SCRIPT_DIR/fzf-url.sh '$extra_filter' '$historyLimit'";


### PR DESCRIPTION
Hey @wfxr 

This commit should capture the entire scrollback history of current tmux pane. I know this isn't an issue/bug but an enhancement of your work. I personally find this more useful since it's not mandatory for a URL just to be present always on screen.

Thanks :)