### PR TITLE
feat: allow to set fzf options with tmux option @fzf-url-fzf-options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ the scrollback history:
 set -g @fzf-url-history-limit '2000'
 ```
 
+You can use custom fzf options by defining `@fzf-url-fzf-options`.
+
+```
+# open tmux-fzf-url in a tmux v3.2+ popup
+set -g @fzf-url-fzf-options '-w 50% -h 50% --multi -0 --no-preview --no-border'
+```
+
 ### 💡 Tips
 
 - Use `tab` to mark multiple urls and open them at once.

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -4,9 +4,15 @@
 #    Email: wenxuangm@gmail.com
 #  Created: 2018-04-06 12:12
 #===============================================================================
+get_fzf_options() {
+    local fzf_options
+    local fzf_default_options='-d 35% -m -0 --no-preview --no-border'
+    fzf_options="$(tmux show -gqv '@fzf-url-fzf-options')"
+    [ -n "$fzf_options" ] && echo "$fzf_options" || echo "$fzf_default_options"
+}
 
 fzf_filter() {
-    fzf-tmux -d 35% -m -0 --no-preview --no-border
+  eval "fzf-tmux $(get_fzf_options)"
 }
 
 open_url() {


### PR DESCRIPTION
Hi @wfxr , first of all THANK YOU so much for this awesome plugin.

I'm using it every day and it really improves my productivity :)

This PR enables passing custom options to `fzf-tmux` using the tmux option `@fzf-url-fzf-options`.
It gracefully retains the original behaviour if the variable is unset.

The tmux option`@fzf-url-fzf-options` is read on invocation of `fzf-url.sh`. 

This allows to set the variable in your `.tmux.conf` or update it on-the-fly as follows:

```
tmux set -g '@fzf-url-fzf-options' \
  '-w 100% -y 100% --no-preview --layout reverse --multi -0 --prompt "url:  " --no-info --pointer ● --color "gutter:-1,pointer:#00ff00"'
```

The resulting tmux popup (tmux `3.2+`) looks like this:

![Screenshot 2021-06-01 at 20 42 34](https://user-images.githubusercontent.com/851258/120374532-f19b0800-c319-11eb-9425-a420a74c8130.png)

