### PR TITLE
fix: urls of the form "https://www.*" show up twice in fzf selection

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -30,7 +30,7 @@ else
 fi
 
 mapfile -t urls < <(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]')
-mapfile -t wwws < <(echo "$content" |grep -oE 'www\.[a-zA-Z](-?[a-zA-Z0-9])+\.[a-zA-Z]{2,}(/\S+)*'                  |sed 's/^\(.*\)$/http:\/\/\1/')
+mapfile -t wwws < <(echo "$content" |grep -oE '(http?s://)?www\.[a-zA-Z](-?[a-zA-Z0-9])+\.[a-zA-Z]{2,}(/\S+)*' | grep -vE '^https?://' |sed 's/^\(.*\)$/http:\/\/\1/')
 mapfile -t ips  < <(echo "$content" |grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?(/\S+)*' |sed 's/^\(.*\)$/http:\/\/\1/')
 mapfile -t gits < <(echo "$content" |grep -oE '(ssh://)?git@\S*' | sed 's/:/\//g' | sed 's/^\(ssh\/\/\/\)\{0,1\}git@\(.*\)$/https:\/\/\2/')
 


### PR DESCRIPTION
This PR fixes the behavior described in #17.

It does so by optionally including `https?://` in the matches found by the `wwws` filter.
The pipe to `grep -vE '^https?://' then filters out these duplicate results (they are already found by the `urls` filter).

The result is a unique selection list that does not include unwanted duplicate results :)