### PR TITLE
display message when no URLs are matched

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -49,7 +49,7 @@ items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${ips[@]}" "${gits[@]}" "${extr
     sort -u |
     nl -w3 -s '  '
 )
-[ -z "$items" ] && exit
+[ -z "$items" ] && tmux display 'tmux-fzf-url: no URLs found' && exit
 
 mapfile -t chosen < <(fzf_filter <<< "$items" | awk '{print $2}')
 


### PR DESCRIPTION
This yields a better user experience, providing feedback on the "unhappy
path".

Tested locally, works as intended.