### PR TITLE
macOS's default bash compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A tmux plugin for opening urls from browser quickly without mouse.
 
 Prerequisites:
 * [`fzf`](https://github.com/junegunn/fzf)
-* [`bash`](https://www.gnu.org/software/bash/) >= `4.0` (macOS ships with `bash` `3.2`!)
+* [`bash`](https://www.gnu.org/software/bash/)
 
 **Install using [TPM](https://github.com/tmux-plugins/tpm)**
 

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -35,13 +35,13 @@ else
     content="$(tmux capture-pane -J -p -S -"$limit")"
 fi
 
-mapfile -t urls < <(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]')
-mapfile -t wwws < <(echo "$content" |grep -oE '(http?s://)?www\.[a-zA-Z](-?[a-zA-Z0-9])+\.[a-zA-Z]{2,}(/\S+)*' | grep -vE '^https?://' |sed 's/^\(.*\)$/http:\/\/\1/')
-mapfile -t ips  < <(echo "$content" |grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?(/\S+)*' |sed 's/^\(.*\)$/http:\/\/\1/')
-mapfile -t gits < <(echo "$content" |grep -oE '(ssh://)?git@\S*' | sed 's/:/\//g' | sed 's/^\(ssh\/\/\/\)\{0,1\}git@\(.*\)$/https:\/\/\2/')
+urls=$(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]')
+wwws=$(echo "$content" |grep -oE '(http?s://)?www\.[a-zA-Z](-?[a-zA-Z0-9])+\.[a-zA-Z]{2,}(/\S+)*' | grep -vE '^https?://' |sed 's/^\(.*\)$/http:\/\/\1/')
+ips=$(echo "$content" |grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?(/\S+)*' |sed 's/^\(.*\)$/http:\/\/\1/')
+gits=$(echo "$content" |grep -oE '(ssh://)?git@\S*' | sed 's/:/\//g' | sed 's/^\(ssh\/\/\/\)\{0,1\}git@\(.*\)$/https:\/\/\2/')
 
 if [[ $# -ge 1 && "$1" != '' ]]; then
-    mapfile -t extras < <(echo "$content" |eval "$1")
+    extras=$(echo "$content" |eval "$1")
 fi
 
 items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${ips[@]}" "${gits[@]}" "${extras[@]}" |
@@ -51,7 +51,7 @@ items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${ips[@]}" "${gits[@]}" "${extr
 )
 [ -z "$items" ] && tmux display 'tmux-fzf-url: no URLs found' && exit
 
-mapfile -t chosen < <(fzf_filter <<< "$items" | awk '{print $2}')
+chosen=$(fzf_filter <<< "$items" | awk '{print $2}')
 
 for item in "${chosen[@]}"; do
     open_url "$item" &>"/tmp/tmux-$(id -u)-fzf-url.log"


### PR DESCRIPTION
Hi @wfxr 

I think you've started using modern bash's builtin (`mapfile`) just to fix linter's suggestions in 5b202610.

Since I've spent some significant time today before I realized that the plugin does not work just because of the default Mac's bash (and also since I do not want to install another version of bash, I just use Mac's default shell: zsh), I've decided to check if your awesome plugin can be made compatible with an old bash.
I've checked the code and ensured that `mapfile` is the only feature which requires modern bash for tmux-fzf-url to work.

I am not a shell scripting expert, but I think the behavior will stay exactly the same if the following:
```bash
mapfile -t urls < <(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]')
```
will be simply replaced with:
```bash
urls=$(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]')
```
and `shellcheck` will not complain.

You anyway do not expect urls with whitespaces and looks like you do not care about them even if it was possible (because you further read an array as `"${urls[@]}"` instead of accessing it's elements by index to respect potential elements with whitespaces).

Please review this change and consider merging it if it does not break anything.