### PR TITLE
Allow escape and add GitHub support

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -13,8 +13,6 @@ get_fzf_options() {
 
 fzf_filter() {
     eval "fzf-tmux $(get_fzf_options)"
-    #TODO investigate if the upstream change supporst $FZF_TMUX_OPTS
-    #eval "fzf-tmux $(get_fzf_options)"
 }
 
 open_url() {

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -54,9 +54,10 @@ items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${gh[@]}" "${ips[@]}" "${gits[@
 
 chosen=$(fzf_filter <<< "$items" | awk '{print $2}')
 
-if [ -z "${chosen[@]}" ]
-  exit 0
+if [ -z $chosen ]
 then
+  exit 0
+else
   for item in "${chosen[@]}"; do
       open_url "$item" &>"/tmp/tmux-$(id -u)-fzf-url.log"
   done

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -12,7 +12,7 @@ get_fzf_options() {
 }
 
 fzf_filter() {
-    eval "fzf-tmux $(get_fzf_options)"
+  eval "fzf-tmux $(get_fzf_options)"
 }
 
 open_url() {

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -39,27 +39,20 @@ urls=$(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:
 wwws=$(echo "$content" |grep -oE '(http?s://)?www\.[a-zA-Z](-?[a-zA-Z0-9])+\.[a-zA-Z]{2,}(/\S+)*' | grep -vE '^https?://' |sed 's/^\(.*\)$/http:\/\/\1/')
 ips=$(echo "$content" |grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?(/\S+)*' |sed 's/^\(.*\)$/http:\/\/\1/')
 gits=$(echo "$content" |grep -oE '(ssh://)?git@\S*' | sed 's/:/\//g' | sed 's/^\(ssh\/\/\/\)\{0,1\}git@\(.*\)$/https:\/\/\2/')
-gh=$(echo "$content" |grep -oE "[\'\"]([A-Za-z0-9-]*\/[.A-Za-z0-9-]*)[\'\"]" | sed "s/\'//g" | sed "s/\"//g" | sed 's/./https\:\/\/github\.com\/&/')
+gh=$(echo "$content" |grep -oE "['\"]([A-Za-z0-9-]*/[.A-Za-z0-9-]*)['\"]" | sed "s/'\|\"//g" | sed 's#.#https://github.com/&#')
 
 if [[ $# -ge 1 && "$1" != '' ]]; then
     extras=$(echo "$content" |eval "$1")
 fi
 
-items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${gh[@]}" "${ips[@]}" "${gits[@]}" "${ghdq[@]}" "${extras[@]}" |
+items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${gh[@]}" "${ips[@]}" "${gits[@]}" "${extras[@]}" |
     grep -v '^$' |
     sort -u |
     nl -w3 -s '  '
 )
 [ -z "$items" ] && tmux display 'tmux-fzf-url: no URLs found' && exit
 
-chosen=$(fzf_filter <<< "$items" | awk '{print $2}')
-
-if [ -z $chosen ]
-then
-  exit 0
-else
-  for item in "${chosen[@]}"; do
-      open_url "$item" &>"/tmp/tmux-$(id -u)-fzf-url.log"
-  done
-fi
-
+fzf_filter <<< "$items" | awk '{print $2}' | \
+    while read -r chosen; do
+        open_url "$chosen" &>"/tmp/tmux-$(id -u)-fzf-url.log"
+    done

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -39,12 +39,13 @@ urls=$(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:
 wwws=$(echo "$content" |grep -oE '(http?s://)?www\.[a-zA-Z](-?[a-zA-Z0-9])+\.[a-zA-Z]{2,}(/\S+)*' | grep -vE '^https?://' |sed 's/^\(.*\)$/http:\/\/\1/')
 ips=$(echo "$content" |grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?(/\S+)*' |sed 's/^\(.*\)$/http:\/\/\1/')
 gits=$(echo "$content" |grep -oE '(ssh://)?git@\S*' | sed 's/:/\//g' | sed 's/^\(ssh\/\/\/\)\{0,1\}git@\(.*\)$/https:\/\/\2/')
+gh=$(echo "$content" |grep -oE "[\'\"]([A-Za-z0-9-]*\/[.A-Za-z0-9-]*)[\'\"]" | sed "s/\'//g" | sed "s/\"//g" | sed 's/./https\:\/\/github\.com\/&/')
 
 if [[ $# -ge 1 && "$1" != '' ]]; then
     extras=$(echo "$content" |eval "$1")
 fi
 
-items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${ips[@]}" "${gits[@]}" "${extras[@]}" |
+items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${gh[@]}" "${ips[@]}" "${gits[@]}" "${ghdq[@]}" "${extras[@]}" |
     grep -v '^$' |
     sort -u |
     nl -w3 -s '  '

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -12,7 +12,7 @@ get_fzf_options() {
 }
 
 fzf_filter() {
-    fzf-tmux $FZF_TMUX_OPTS -m -0 --no-preview --no-border
+    eval "fzf-tmux $(get_fzf_options)"
     #TODO investigate if the upstream change supporst $FZF_TMUX_OPTS
     #eval "fzf-tmux $(get_fzf_options)"
 }

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -54,6 +54,11 @@ items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${gh[@]}" "${ips[@]}" "${gits[@
 
 chosen=$(fzf_filter <<< "$items" | awk '{print $2}')
 
-for item in "${chosen[@]}"; do
-    open_url "$item" &>"/tmp/tmux-$(id -u)-fzf-url.log"
-done
+if [ -z "${chosen[@]}" ]
+  exit 0
+then
+  for item in "${chosen[@]}"; do
+      open_url "$item" &>"/tmp/tmux-$(id -u)-fzf-url.log"
+  done
+fi
+


### PR DESCRIPTION
I added two new features!

1. Allow the use to hit escape to quit the popup and do nothing. Previously if you hit escape it would open the file explorer.
2. Add GitHub support. Many config files include `user-name/repo-name` strings that reference GitHub repos. I've added a `gh` type to the detect those strings and add `github.com` links to the selector.

<img width="1890" alt="Screenshot 2022-12-21 at 3 58 43 PM" src="https://user-images.githubusercontent.com/2036594/209010227-92c7c4e5-ffe4-4818-af04-fdc730026b92.png">
