### PR TITLE
Fix nothing-chosen and multiple-chosen cases

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -51,8 +51,7 @@ items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${ips[@]}" "${gits[@]}" "${extr
 )
 [ -z "$items" ] && tmux display 'tmux-fzf-url: no URLs found' && exit
 
-chosen=$(fzf_filter <<< "$items" | awk '{print $2}')
-
-for item in "${chosen[@]}"; do
-    open_url "$item" &>"/tmp/tmux-$(id -u)-fzf-url.log"
-done
+printf '%s' "$items" | fzf_filter | awk '{print $2}' | \
+    while read -r chosen; do
+        open_url "$chosen" &>"/tmp/tmux-$(id -u)-fzf-url.log"
+    done


### PR DESCRIPTION
With previous version:
1. Exiting fzf without choosing a URL leads to the following error in tmux:
```
'/home/user/.tmux/plugins/tmux-fzf-url/fzf-url.sh '' screen' returned 1
```
2. Choosing multiple URLs leads to them being joined into a single one

Bash version 5.1.16 on Linux.