### PR TITLE
Parse away single/double quotes for gh matches

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -39,7 +39,7 @@ urls=$(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:
 wwws=$(echo "$content" |grep -oE '(http?s://)?www\.[a-zA-Z](-?[a-zA-Z0-9])+\.[a-zA-Z]{2,}(/\S+)*' | grep -vE '^https?://' |sed 's/^\(.*\)$/http:\/\/\1/')
 ips=$(echo "$content" |grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?(/\S+)*' |sed 's/^\(.*\)$/http:\/\/\1/')
 gits=$(echo "$content" |grep -oE '(ssh://)?git@\S*' | sed 's/:/\//g' | sed 's/^\(ssh\/\/\/\)\{0,1\}git@\(.*\)$/https:\/\/\2/')
-gh=$(echo "$content" |grep -oE "['\"]([A-Za-z0-9-]*/[.A-Za-z0-9-]*)['\"]" | sed "s/'\|\"//g" | sed 's#.#https://github.com/&#')
+gh=$(echo "$content" |grep -oE "['\"]([A-Za-z0-9-]*/[.A-Za-z0-9-]*)['\"]" | sed "s/['\"]//g" | sed 's#.#https://github.com/&#')
 
 if [[ $# -ge 1 && "$1" != '' ]]; then
     extras=$(echo "$content" |eval "$1")


### PR DESCRIPTION
Before:
```
    7  https://github.com/'wfxr/tmux-fzf-url'
    6  https://github.com/'tmux-plugins/tpm'
    5  https://github.com/'tmux-plugins/tmux-yank'
    4  https://github.com/'soyuka/tmux-current-pane-hostname'
    3  https://github.com/'seebi/tmux-colors-solarized'
    2  https://github.com/'roosta/tmux-fuzzback'
>   1  https://github.com/'christoomey/vim-tmux-navigator'
```
After:
```
    7  https://github.com/wfxr/tmux-fzf-url
    6  https://github.com/tmux-plugins/tpm
    5  https://github.com/tmux-plugins/tmux-yank
    4  https://github.com/soyuka/tmux-current-pane-hostname
    3  https://github.com/seebi/tmux-colors-solarized
    2  https://github.com/roosta/tmux-fuzzback
>   1  https://github.com/christoomey/vim-tmux-navigator
```