### PR TITLE
Added  `@fzf-url-open`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ You can use custom fzf options by defining `@fzf-url-fzf-options`.
 set -g @fzf-url-fzf-options '-w 50% -h 50% --multi -0 --no-preview --no-border'
 ```
 
+By default, `tmux-fzf-url` will use `xdg-open`, `open`, or the `BROWSER`
+environment variable to open the url, respectively. If you want to use a
+different command, you can set `@fzf-url-open` to the command you want to use.
+
+```tmux
+set -g @fzf-url-open "firefox"
+```
+
 ### 💡 Tips
 
 - You can mark multiple urls and open them at once.

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -15,8 +15,11 @@ fzf_filter() {
   eval "fzf-tmux $(get_fzf_options)"
 }
 
+custom_open=$3
 open_url() {
-    if hash xdg-open &>/dev/null; then
+    if [[ -n $custom_open ]]; then 
+        $custom_open "$@"
+    elif hash xdg-open &>/dev/null; then
         nohup xdg-open "$@"
     elif hash open &>/dev/null; then
         nohup open "$@"
@@ -24,7 +27,6 @@ open_url() {
         nohup "$BROWSER" "$@"
     fi
 }
-
 
 limit='screen'
 [[ $# -ge 2 ]] && limit=$2
@@ -52,9 +54,7 @@ items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${gh[@]}" "${ips[@]}" "${gits[@
 )
 [ -z "$items" ] && tmux display 'tmux-fzf-url: no URLs found' && exit
 
-custom_open=$3
-[[ -n $custom_open ]] && opener=$custom_open || opener="open_url"
 fzf_filter <<< "$items" | awk '{print $2}' | \
     while read -r chosen; do
-        eval "$opener $chosen" &>"/tmp/tmux-$(id -u)-fzf-url.log"
+        open_url "$chosen" &>"/tmp/tmux-$(id -u)-fzf-url.log"
     done

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -52,7 +52,9 @@ items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${gh[@]}" "${ips[@]}" "${gits[@
 )
 [ -z "$items" ] && tmux display 'tmux-fzf-url: no URLs found' && exit
 
+custom_open=$3
+[[ -n $custom_open ]] && opener=$custom_open || opener="open_url"
 fzf_filter <<< "$items" | awk '{print $2}' | \
     while read -r chosen; do
-        open_url "$chosen" &>"/tmp/tmux-$(id -u)-fzf-url.log"
+        eval "$opener $chosen" &>"/tmp/tmux-$(id -u)-fzf-url.log"
     done

--- a/fzf-url.tmux
+++ b/fzf-url.tmux
@@ -17,6 +17,7 @@ tmux_get() {
 key="$(tmux_get '@fzf-url-bind' 'u')"
 history_limit="$(tmux_get '@fzf-url-history-limit' 'screen')"
 extra_filter="$(tmux_get '@fzf-url-extra-filter' '')"
+custom_open="$(tmux_get '@fzf-url-open' '')"
 echo "$extra_filter" > /tmp/filter
 
-tmux bind-key "$key" run -b "$SCRIPT_DIR/fzf-url.sh '$extra_filter' $history_limit";
+tmux bind-key "$key" run -b "$SCRIPT_DIR/fzf-url.sh '$extra_filter' $history_limit $custom_open";

--- a/fzf-url.tmux
+++ b/fzf-url.tmux
@@ -20,4 +20,4 @@ extra_filter="$(tmux_get '@fzf-url-extra-filter' '')"
 custom_open="$(tmux_get '@fzf-url-open' '')"
 echo "$extra_filter" > /tmp/filter
 
-tmux bind-key "$key" run -b "$SCRIPT_DIR/fzf-url.sh '$extra_filter' $history_limit $custom_open";
+tmux bind-key "$key" run -b "$SCRIPT_DIR/fzf-url.sh '$extra_filter' $history_limit '$custom_open'";


### PR DESCRIPTION
I did not want to use `xdg-open` for opening files. However, I could not uninstall `xdg-open` as other programs depend on it. As a solution I added the `@fzf-url-open` setting. When this setting is applied, it takes precedence over `xdg-open`, `open` and BROWSER.

Thanks for building this repo. I use it everyday!