### PR TITLE
[Feature] Secondary key-binding U removing newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,18 @@ Clone this repo somewhere and source `fzf-url.tmux` at the config file.
 
 ### 📝 Usage
 
-The default key-binding is `u`(of course prefix hit is needed), it can be modified by
+The default main key-binding is `u`(of course prefix hit is needed), it can be modified by
 setting value to `@fzf-url-bind` at the tmux config like this:
 
 ``` tmux
 set -g @fzf-url-bind 'x'
+```
+
+A secondary key-binding, eliminating newlines from the capture, is `U` , it can be modified by
+setting value to `@fzf-url-bind-no-newlines`:
+
+``` tmux
+set -g @fzf-url-bind-no-newlines 'X'
 ```
 
 You can also extend the capture groups by defining `@fzf-url-extra-filter`:
@@ -68,6 +75,7 @@ set -g @fzf-url-open "firefox"
 
 - You can mark multiple urls and open them at once.
 - The tmux theme showed in the screenshot is [tmux-power](https://github.com/wfxr/tmux-power).
+- The no-newlines key-binding is useful for some programs badly wrapping long Urls, e.g., neomutt mail client.
 
 ### 🔗 Other plugins
 

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -17,7 +17,7 @@ fzf_filter() {
 
 custom_open=$3
 open_url() {
-    if [[ -n $custom_open ]]; then 
+    if [[ -n $custom_open ]]; then
         $custom_open "$@"
     elif hash xdg-open &>/dev/null; then
         nohup xdg-open "$@"
@@ -35,6 +35,10 @@ if [[ $limit == 'screen' ]]; then
     content="$(tmux capture-pane -J -p -e)"
 else
     content="$(tmux capture-pane -J -p -e -S -"$limit")"
+fi
+
+if [[ $4 == 'no-newlines' ]]; then
+  content=$(echo "$content" | tr -d '\n')
 fi
 
 urls=$(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]')

--- a/fzf-url.tmux
+++ b/fzf-url.tmux
@@ -15,9 +15,12 @@ tmux_get() {
 }
 
 key="$(tmux_get '@fzf-url-bind' 'u')"
+key2="$(tmux_get '@fzf-url-bind-no-newlines' 'U')"
 history_limit="$(tmux_get '@fzf-url-history-limit' 'screen')"
 extra_filter="$(tmux_get '@fzf-url-extra-filter' '')"
 custom_open="$(tmux_get '@fzf-url-open' '')"
 echo "$extra_filter" > /tmp/filter
 
-tmux bind-key "$key" run -b "$SCRIPT_DIR/fzf-url.sh '$extra_filter' $history_limit '$custom_open'";
+tmux bind-key "$key" run -b "$SCRIPT_DIR/fzf-url.sh '$extra_filter' $history_limit '$custom_open' ''";
+tmux bind-key "$key2" run -b "$SCRIPT_DIR/fzf-url.sh '$extra_filter' $history_limit '$custom_open' 'no-newlines'";
+


### PR DESCRIPTION
## Intro

I'm using [Neomutt](https://github.com/neomutt/neomutt/) TUI email client.
The main issue was, for me, that the internal pager does not rely on the terminal to wrap the long Urls.
As explained in this [issue](https://github.com/neomutt/neomutt/), it does insert newlines in lines to wrap them, **which break most url extraction tools like the current tmux-fzf-url** or the perl script in the URxvt terminal.

## Feature

This PR introduce a new feature to work around this issue by **removing every newlines in the captured content from Tmux, before the regex parsing**.

- This new feature is not an option but a secondary key-binding, by default 'U'.

I separated it in another key-binding because the captured urls might wrongly expand in some cases, e.g, if an Url matches perfectly the screen width and is followed by another string in the beginning of the next line.

But in cases like Neomutt it's a perfect solution.