### PR TITLE
Strip escape sequences before fzf selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Prerequisites:
 * [`fzf`](https://github.com/junegunn/fzf)
 * [`bash`](https://www.gnu.org/software/bash/)
 
+Optional dependency:
+* [`ansifilter`](https://gitlab.com/saalen/ansifilter)
+
 **Install using [TPM](https://github.com/tmux-plugins/tpm)**
 
 Add this line to your tmux config file, then hit `prefix + I`:

--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -47,9 +47,13 @@ if [[ $# -ge 1 && "$1" != '' ]]; then
     extras=$(echo "$content" |eval "$1")
 fi
 
+# If ansifilter is unavailable, define it as a noop.
+if ! command -v ansifilter > /dev/null; then ansifilter() { while read -r data; do echo "$data"; done }; fi
+
 items=$(printf '%s\n' "${urls[@]}" "${wwws[@]}" "${gh[@]}" "${ips[@]}" "${gits[@]}" "${extras[@]}" |
     grep -v '^$' |
     sort -u |
+    ansifilter |
     nl -w3 -s '  '
 )
 [ -z "$items" ] && tmux display 'tmux-fzf-url: no URLs found' && exit


### PR DESCRIPTION
This patch strips fzf items with `ansifilter`[1] if it's available, also mentioning it in the README.

[1]: http://andre-simon.de/doku/ansifilter/en/sfnet.php

I'm not sure why db053fa17ec51aae3be80a99ad24e8c30f620770 adds them, neither `tmux-fpp` nor `tmux-urlview` seems to do this. However, I did end up with these sequences among the selection items (and the browser tried to open them, with 404s as results), so I feel a strip here is needed. Unless a revert of db053fa17ec51aae3be80a99ad24e8c30f620770 is better, but I don't understand the reasoning behind it so strip it is.

Thanks for this plugin.
