### PR TITLE
Fix issue where URLs were not accurately retrieved when ANSI sequences were included

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -32,9 +32,9 @@ limit='screen'
 [[ $# -ge 2 ]] && limit=$2
 
 if [[ $limit == 'screen' ]]; then
-    content="$(tmux capture-pane -J -p -e)"
+    content="$(tmux capture-pane -J -p -e |sed -r 's/\x1B\[[0-9;]*[mK]//g'))"
 else
-    content="$(tmux capture-pane -J -p -e -S -"$limit")"
+    content="$(tmux capture-pane -J -p -e -S -"$limit" |sed -r 's/\x1B\[[0-9;]*[mK]//g'))"
 fi
 
 urls=$(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]')


### PR DESCRIPTION
Fixes this issue: https://github.com/wfxr/tmux-fzf-url/issues/52

This PR resolves an issue where URLs could not be captured from the startup logs of Vue applications.


before | after
-- | --
<img width="411" alt="image" src="https://github.com/user-attachments/assets/f4e465ed-1f50-415b-a904-331addbc04f9"> | <img width="535" alt="image" src="https://github.com/user-attachments/assets/dfdbb9f9-142a-45ef-9220-0d7303203fcd">
