### PR TITLE
fix: macOS compatibility for ANSI stripping and URL opening

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -28,8 +28,10 @@ open_url() {
         $custom_open "$@"
     elif hash xdg-open &>/dev/null; then
         nohup xdg-open "$@"
-    elif hash open &>/dev/null; then
-        nohup open "$@"
+    elif [[ "$(uname)" == "Darwin" ]]; then
+        for url in "$@"; do
+            osascript -e "tell application \"System Events\" to open location \"$url\""
+        done
     elif [[ -n $BROWSER ]]; then
         nohup "$BROWSER" "$@"
     fi
@@ -39,9 +41,9 @@ limit='screen'
 [[ $# -ge 2 ]] && limit=$2
 
 if [[ $limit == 'screen' ]]; then
-    content="$(tmux capture-pane -J -p -e |sed -r 's/\x1B\[[0-9;]*[mK]//g'))"
+    content="$(tmux capture-pane -J -p -e |sed -E 's/\x1B\[[0-9;]*[mK]//g')"
 else
-    content="$(tmux capture-pane -J -p -e -S -"$limit" |sed -r 's/\x1B\[[0-9;]*[mK]//g'))"
+    content="$(tmux capture-pane -J -p -e -S -"$limit" |sed -E 's/\x1B\[[0-9;]*[mK]//g')"
 fi
 
 urls=$(echo "$content" |grep -oE '(https?|ftp|file):/?//[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]')

--- a/fzf-url.tmux
+++ b/fzf-url.tmux
@@ -20,4 +20,4 @@ extra_filter="$(tmux_get '@fzf-url-extra-filter' '')"
 custom_open="$(tmux_get '@fzf-url-open' '')"
 echo "$extra_filter" > /tmp/filter
 
-tmux bind-key "$key" run -b "$SCRIPT_DIR/fzf-url.sh '$extra_filter' $history_limit '$custom_open'";
+tmux bind-key "$key" run "$SCRIPT_DIR/fzf-url.sh '$extra_filter' $history_limit '$custom_open'";


### PR DESCRIPTION
PR #53 introduced two macOS issues:

1. `sed -r` is GNU-only, replaced with `sed -E` (works on both GNU and BSD)
2. Extra `)` in command substitution causing syntax error
3. `open` fails with `procNotFound` inside tmux (no Launch Services access), replaced with `osascript` via System Events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS URL/opening so each selected location opens reliably.
  * Adjusted tmux binding so the launcher runs without forced backgrounding, improving interactive behavior when invoked from tmux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->