### PR TITLE
fix: use osascript for opening URLs on macOS

### DIFF
--- a/fzf-url.sh
+++ b/fzf-url.sh
@@ -38,10 +38,14 @@ open_url() {
         else
             nohup explorer.exe "$@"
         fi
+    elif [[ "$(uname)" == "Darwin" ]]; then
+        for url in "$@"; do
+            osascript -e 'on run argv' -e 'tell application "System Events" to open location (item 1 of argv)' -e 'end run' -- "$url"
+        done
     elif hash xdg-open &>/dev/null; then
         nohup xdg-open "$@"
     elif hash open &>/dev/null; then
-        nohup open "$@"
+        open "$@"
     elif [[ -n $BROWSER ]]; then
         nohup "$BROWSER" "$@"
     fi


### PR DESCRIPTION
## Summary

`nohup open` fails inside tmux on macOS with `procNotFound` (`NSOSStatusErrorDomain Code=-600`) because the tmux server process lacks a Launch Services connection.

## Reproduction

Trigger the URL picker keybinding, select a URL. The user sees:

```
'/path/to/fzf-url.sh' '2000' '' '' '' '' returned 1
```

The fzf-url log shows:

```
The application cannot be opened for an unexpected reason,
error=Error Domain=NSOSStatusErrorDomain Code=-600
"procNotFound: no eligible process with specified descriptor"
```

## Fix

- Add explicit Darwin branch using `osascript` via System Events, which works regardless of process context. URL is passed as an argv argument to avoid string interpolation issues.
- Darwin branch is checked before `xdg-open` so macOS always takes the correct path.
- BSD `open` fallback preserved (without `nohup`) for FreeBSD/OpenBSD.